### PR TITLE
Revert .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
     - mv include/nitro/specfiles/ARM7-TS.lcf.template $TRAVIS_BUILD_DIR/arm7
     - mv include/nitro/specfiles/ARM9-TS.lcf.template $TRAVIS_BUILD_DIR/arm9
     - popd
-    - for fl in files/msgdata/msg/*.txt; do iconv -f utf-16 $fl > tmp.txt && mv tmp.txt $fl; done || true
 
 script:
     - travis_retry make


### PR DESCRIPTION
The `for` loop being removed was inserted to force a build to pass after changing file encodings.