### PR TITLE
Add support for building on macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,19 +70,21 @@ $ brew install --cask xquartz
 $ brew install --cask --no-quarantine wine-stable
 ```
 
-To build the project, run the below commands:
-
-```console
-$ export PATH=/usr/local/opt/llvm@8/bin:$PATH SHA1SUM=shasum CC=clang CXX=clang++
-$ gmake
-```
-
 ### 4. Build ROM
 
 Run `make` to build the ROM. The ROM will be output as `build/diamond.us/pokediamond.us.nds`
 
 To build Pokemon Pearl, run `make pearl`. You do not need to clean your working tree in between compiling. Pokemon Pearl will be built as `build/pearl.us/pokepearl.us.nds`.
 
-Windows Users:
+#### Windows
 
 If you get an error in saving configuration settings when specifying the license file, you need to add a system environment variable called LM_LICENSE_FILE and point it to the license.dat file. Alternatively, run mwccarm.exe from an Administrator command prompt, PowerShell, or WSL session.
+
+#### macOS
+
+To avoid issues run the build as shown below. This avoids issues with missing features (i.e. "introduced in macOS 10.15" errors) and Apple's make not following standards.
+
+```console
+$ export PATH=/usr/local/opt/llvm@8/bin:$PATH CC=clang CXX=clang++
+$ gmake
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,6 +48,35 @@ Install them using either the Cygwin package manager or using pacman on Msys2.
 
 **NOTE FOR MSYS2:** You will need to compile and install [libpng](https://www.libpng.org/pub/png/libpng.html) from source.
 
+#### macOS
+
+**macOS 10.14 Mojave or older is required**. macOS 10.15 Catalina is not supported due to missing support for 32-bit binaries (thus making wine emulation unfeasible). You will also require the following packages:
+
+* GNU make
+* LLVM 8 clang compiler
+* gcc@5 (for mwasmarm_patcher)
+* arm-gcc-bin
+* git
+* libpng
+* wine-stable and xquartz dependency
+
+They can be installed with the following commands:
+
+```console
+$ brew tap osx-cross/homebrew-arm
+$ brew tap homebrew/cask-versions
+$ brew install make llvm@8 gcc@5 arm-gcc-bin libpng git
+$ brew install --cask xquartz
+$ brew install --cask --no-quarantine wine-stable
+```
+
+To build the project, run the below commands:
+
+```console
+$ export PATH=/usr/local/opt/llvm@8/bin:$PATH SHA1SUM=shasum CC=clang CXX=clang++
+$ gmake
+```
+
 ### 4. Build ROM
 
 Run `make` to build the ROM. The ROM will be output as `build/diamond.us/pokediamond.us.nds`

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,11 @@ LDFLAGS = -map -nodead -w off -proc v5te -interworking -map -symtab -m _start
 
 # DS TOOLS
 TOOLS_DIR = tools
+ifeq ($(UNAME_S),Darwin)
+SHA1SUM = shasum
+else
 SHA1SUM = sha1sum
+endif
 CSV2BIN = $(TOOLS_DIR)/csv2bin/csv2bin$(EXE)
 JSONPROC = $(TOOLS_DIR)/jsonproc/jsonproc$(EXE)
 O2NARC = $(TOOLS_DIR)/o2narc/o2narc$(EXE)

--- a/arm7/Makefile
+++ b/arm7/Makefile
@@ -96,7 +96,12 @@ LDFLAGS = -map -nodead -w off -proc v4t -interworking -map -symtab -m _start
 ####################### Other Tools #########################
 
 # DS TOOLS
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+SHA1SUM = shasum
+else
 SHA1SUM = sha1sum
+endif
 JSONPROC = $(TOOLS_DIR)/jsonproc/jsonproc
 GFX = $(TOOLS_DIR)/nitrogfx/nitrogfx
 SCANINC = $(TOOLS_DIR)/scaninc/scaninc$(EXE)

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -120,10 +120,15 @@ STATIC_LIBS := $(addprefix $(BUILD_DIR)/lib/,libsyscall.a)
 ####################### Other Tools #########################
 
 # DS TOOLS
-ifndef BUSYBOX
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+SHA1SUM = shasum
+else
+ifdef BUSYBOX
 SHA1SUM = sha1sum --quiet
 else
 SHA1SUM = sha1sum
+endif
 endif
 JSONPROC = $(TOOLS_DIR)/jsonproc/jsonproc$(EXE)
 GFX = $(TOOLS_DIR)/nitrogfx/nitrogfx$(EXE)

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -124,7 +124,7 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
 SHA1SUM = shasum
 else
-ifdef BUSYBOX
+ifndef BUSYBOX
 SHA1SUM = sha1sum --quiet
 else
 SHA1SUM = sha1sum

--- a/tools/knarc/Makefile
+++ b/tools/knarc/Makefile
@@ -8,7 +8,7 @@ else
 C_SRCS   :=
 UNAME_S  := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-LDFLAGS  += -lstdc++ -lc++ -lc
+LDFLAGS  += -lstdc++ -lc++ -lc /usr/local/opt/llvm@8/lib/libc++fs.a -O2 -Wall -Wno-switch
 else
 LDFLAGS  += -lstdc++fs
 endif

--- a/tools/knarc/Makefile
+++ b/tools/knarc/Makefile
@@ -8,7 +8,7 @@ else
 C_SRCS   :=
 UNAME_S  := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-LDFLAGS  += -lstdc++ -lc++ -lc /usr/local/opt/llvm@8/lib/libc++fs.a -O2 -Wall -Wno-switch
+LDFLAGS  += -lstdc++ -lc++ -lc /usr/local/opt/llvm@8/lib/libc++fs.a
 else
 LDFLAGS  += -lstdc++fs
 endif

--- a/tools/mwasmarm_patcher/Makefile
+++ b/tools/mwasmarm_patcher/Makefile
@@ -1,6 +1,11 @@
 .PHONY: all clean
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+CC := gcc-5
+else
 CC := gcc
+endif
 CFLAGS := -O3
 
 .PHONY: all clean


### PR DESCRIPTION
I found a few issues when I tried to build the project on my Mac. Most notable were:

* Wine emulation required for this project is not supported in macOS 10.15, due to having dropped 32-bit binaries support. Fortunately a downgrade to 10.14 is not too complex.
* Apple's gcc is not compatible with the project, due to missing experimental/filesystem. It was added in 10.15, but this is not supported (see above)
* Brew's gcc is not compatible due to missing certain headers in 10.14. I could workaround this with LLVM.
* I could not get mwasmarm_patcher to work with any newer gcc than Brew's gcc@5.
* In macOS, sha1sum is not available, instead shasum should be used

P.S.: If you have any concerns with modifying these files, it's fine for me, and it can be closed. Just wanted to leave a PR for anyone finding issues building the project in their own Mac in the future.