### PR TITLE
Fix a bunch of function signatures

### DIFF
--- a/arm9/src/unk_0204639C.c
+++ b/arm9/src/unk_0204639C.c
@@ -4,7 +4,7 @@
 
 #pragma thumb on
 
-struct UnkStruct_0204639C * FUN_0204639C(struct UnkStruct_0204639C * r5, UnkStruct_0204639C_cb r6, u32 * r7)
+struct UnkStruct_0204639C * FUN_0204639C(struct UnkSavStruct80 * r5, UnkStruct_0204639C_cb r6, u32 * r7)
 {
     struct UnkStruct_0204639C * ret = AllocFromHeapAtEnd(32, sizeof(struct UnkStruct_0204639C));
     ret->unk0 = 0;
@@ -18,10 +18,9 @@ struct UnkStruct_0204639C * FUN_0204639C(struct UnkStruct_0204639C * r5, UnkStru
     return ret;
 }
 
-void FUN_020463CC(struct UnkStruct_0204639C * r5, UnkStruct_0204639C_cb r4, u32 * r6)
+void FUN_020463CC(struct UnkSavStruct80 * r5, UnkStruct_0204639C_cb r4, u32 * r6)
 {
-    if (r5->unk10 != NULL)
-        ErrorHandling();
+    GF_ASSERT(r5->unk10 == NULL);
     r5->unk10 = FUN_0204639C(r5, r4, r6);
 }
 
@@ -85,7 +84,7 @@ BOOL FUN_020464A4(void * r0)
 
 BOOL FUN_020464B8(struct UnkStruct_0204639C * r4)
 {
-    struct UnkStruct_0204639C * r5 = FUN_02046528(r4);
+    struct UnkSavStruct80 * r5 = FUN_02046528(r4);
     u32 * r4_2 = FUN_0204652C(r4);
     switch (r4_2[0])
     {
@@ -113,7 +112,7 @@ void FUN_02046500(struct UnkStruct_0204639C * r6, u32 r5, u32 r4)
     FUN_0204640C(r6, FUN_020464B8, r2);
 }
 
-struct UnkStruct_0204639C * FUN_02046528(struct UnkStruct_0204639C * r0)
+struct UnkSavStruct80 * FUN_02046528(struct UnkStruct_0204639C * r0)
 {
     return r0->unk18;
 }

--- a/arm9/src/unk_0204AEA8.c
+++ b/arm9/src/unk_0204AEA8.c
@@ -3,12 +3,12 @@
 #include "unk_0204639C.h"
 #include "unk_0204AEA8.h"
 
-extern void MOD05_021E3444(u32, struct UnkStruct_0204639C *, u32);
+extern void MOD05_021E3444(u32, struct UnkSavStruct80 *, u32);
 extern void FUN_0200433C(u32, u16, u32);
 
 THUMB_FUNC BOOL FUN_0204AEA8(struct UnkStruct_0204639C *a0)
 {
-    struct UnkStruct_0204639C *v0 = FUN_02046528(a0);
+    struct UnkSavStruct80 *v0 = FUN_02046528(a0);
     u32 *v1 = FUN_0204652C(a0);
 
     switch (v1[0])

--- a/arm9/src/unk_0205FA2C.c
+++ b/arm9/src/unk_0205FA2C.c
@@ -5,12 +5,12 @@ extern void *UNK_020FA6E8;
 extern u32 FUN_02079C70(struct SaveBlock2 *sav2);
 extern void FUN_0207B000(struct UnkPlayerStruct2_0205FA2C *ptr, const u8 param1[12]);
 extern void FUN_0207C2A4(struct UnkPlayerStruct2_0205FA2C *ptr, struct PlayerData *player_data);
-extern u32 FUN_0203384C(u32 *param0);
-extern u32 *FUN_02038790(struct UnkStruct_0204639C *param0, u16 param1, u16 param2);
+extern u32 FUN_0203384C(struct SaveBlock2 *sav2);
+extern u32 *FUN_02038790(struct UnkSavStruct80 *param0, u16 param1, u16 param2);
 extern u16 *GetVarPointer(struct UnkSavStruct80 *arg, u16);
-extern u16 MOD06_02244660(struct UnkStruct_0204639C *param0, u8 *param1);
-extern u16 MOD06_022446BC(struct UnkStruct_0204639C *param0, u8 *param1);
-extern u16 MOD06_022446E0(struct UnkStruct_0204639C *param0, u8 *param1);
+extern u16 MOD06_02244660(struct UnkSavStruct80 *param0, u8 *param1);
+extern u16 MOD06_022446BC(struct UnkSavStruct80 *param0, u8 *param1);
+extern u16 MOD06_022446E0(struct UnkSavStruct80 *param0, u8 *param1);
 extern void FUN_0202A5CC(u32 param0, u32 param1);
 extern u32 FUN_0202A5D0(u32 param0);
 extern u32 FUN_0202A150(struct UnkStruct_02029FB0 *param0, u32 param1);
@@ -36,12 +36,12 @@ const u8 UNK_020F7454[] = {
 };
 
 THUMB_FUNC u32 FUN_0205FA2C(
-    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkStruct_0204639C *param1, u32 heap_id)
+    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkSavStruct80 *param1, u32 heap_id)
 {
     struct UnkPlayerStruct1_0205FA2C *ptr = (struct UnkPlayerStruct1_0205FA2C *)AllocFromHeapAtEnd(
         heap_id, sizeof(struct UnkPlayerStruct1_0205FA2C));
 
-    struct SaveBlock2 *sav2 = (struct SaveBlock2 *)(param1->unkC);
+    struct SaveBlock2 *sav2 = param1->saveBlock2;
     MI_CpuFill8(ptr, 0, sizeof(struct UnkPlayerStruct1_0205FA2C));
 
     ptr->options = Sav2_PlayerData_GetOptionsAddr(sav2);
@@ -70,7 +70,7 @@ THUMB_FUNC u32 FUN_0205FA2C(
 }
 
 THUMB_FUNC u32 FUN_0205FAD8(
-    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkStruct_0204639C *param1)
+    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkSavStruct80 *param1)
 {
     if (FUN_0204647C(param1))
     {
@@ -105,9 +105,9 @@ THUMB_FUNC u32 FUN_0205FAD8(
 }
 
 THUMB_FUNC u32 FUN_0205FB34(
-    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkStruct_0204639C *param1, u32 heap_id)
+    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkSavStruct80 *param1, u32 heap_id)
 {
-    struct SaveBlock2 *sav2 = (struct SaveBlock2 *)(param1->unkC);
+    struct SaveBlock2 *sav2 = param1->saveBlock2;
 
     struct UnkPlayerStruct2_0205FA2C *ptr = (struct UnkPlayerStruct2_0205FA2C *)AllocFromHeapAtEnd(
         heap_id, sizeof(struct UnkPlayerStruct2_0205FA2C));
@@ -140,7 +140,7 @@ THUMB_FUNC u32 FUN_0205FB34(
 }
 
 THUMB_FUNC u32 FUN_0205FBC0(
-    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkStruct_0204639C *param1)
+    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkSavStruct80 *param1)
 {
     if (FUN_0204647C(param1))
     {
@@ -158,7 +158,7 @@ THUMB_FUNC u32 FUN_0205FBC0(
 
 THUMB_FUNC int FUN_0205FBE8(struct UnkStruct_0204639C *param0)
 {
-    struct UnkStruct_0204639C *res = FUN_02046528(param0);
+    struct UnkSavStruct80 *res = FUN_02046528(param0);
     struct UnkCallbackStruct1_0205FA2C *res2 =
         (struct UnkCallbackStruct1_0205FA2C *)FUN_0204652C(param0);
     switch (res2->unk04)
@@ -192,7 +192,7 @@ THUMB_FUNC void FUN_0205FC50(struct UnkStruct_0204639C *param0,
     u8 param6,
     u8 param7)
 {
-    struct UnkStruct_0204639C *res = FUN_02046528(param0);
+    struct UnkSavStruct80 *res = FUN_02046528(param0);
 
     struct UnkCallbackStruct1_0205FA2C *ptr = (struct UnkCallbackStruct1_0205FA2C *)AllocFromHeap(
         0xb, sizeof(struct UnkCallbackStruct1_0205FA2C));
@@ -210,9 +210,9 @@ THUMB_FUNC void FUN_0205FC50(struct UnkStruct_0204639C *param0,
 }
 
 THUMB_FUNC u32 FUN_0205FC9C(
-    struct UnkCallbackStruct2_0205FA2C *param0, struct UnkStruct_0204639C *param1)
+    struct UnkCallbackStruct2_0205FA2C *param0, struct UnkSavStruct80 *param1)
 {
-    if (FUN_0203384C(param1->unkC))
+    if (FUN_0203384C(param1->saveBlock2))
     {
 
         param0->unk08 = FUN_02038790(param1, param0->unk12, param0->unk14);
@@ -224,7 +224,7 @@ THUMB_FUNC u32 FUN_0205FC9C(
 }
 
 THUMB_FUNC u32 FUN_0205FCC4(
-    struct UnkCallbackStruct2_0205FA2C *param0, struct UnkStruct_0204639C *param1)
+    struct UnkCallbackStruct2_0205FA2C *param0, struct UnkSavStruct80 *param1)
 {
     if (FUN_0204647C(param1))
     {
@@ -239,7 +239,7 @@ THUMB_FUNC u32 FUN_0205FCC4(
 
 THUMB_FUNC int FUN_0205FCE8(struct UnkStruct_0204639C *param0)
 {
-    struct UnkStruct_0204639C *res = FUN_02046528(param0);
+    struct UnkSavStruct80 *res = FUN_02046528(param0);
     struct UnkCallbackStruct2_0205FA2C *res2 =
         (struct UnkCallbackStruct2_0205FA2C *)FUN_0204652C(param0);
 
@@ -252,7 +252,7 @@ THUMB_FUNC int FUN_0205FCE8(struct UnkStruct_0204639C *param0)
         res2->unk04 = FUN_0205FCC4(res2, res);
         break;
     case 2:
-        u16 *var = GetVarPointer((struct UnkSavStruct80 *)res, res2->unk10);
+        u16 *var = GetVarPointer(res, res2->unk10);
         *var = (u16)res2->unk00;
         FreeToHeap(res2);
 
@@ -264,7 +264,7 @@ THUMB_FUNC int FUN_0205FCE8(struct UnkStruct_0204639C *param0)
 
 THUMB_FUNC void FUN_0205FD38(struct UnkStruct_0204639C *param0, u16 param1, u16 param2, u16 param3)
 {
-    struct UnkStruct_0204639C *res = FUN_02046528(param0);
+    struct UnkSavStruct80 *res = FUN_02046528(param0);
     struct UnkCallbackStruct2_0205FA2C *ptr = (struct UnkCallbackStruct2_0205FA2C *)AllocFromHeap(
         0xb, sizeof(struct UnkCallbackStruct2_0205FA2C));
     MI_CpuFill8(ptr, 0, sizeof(struct UnkCallbackStruct2_0205FA2C));
@@ -278,7 +278,7 @@ THUMB_FUNC void FUN_0205FD38(struct UnkStruct_0204639C *param0, u16 param1, u16 
 
 THUMB_FUNC int FUN_0205FD70(struct UnkStruct_0204639C *param0)
 {
-    struct UnkStruct_0204639C *res = FUN_02046528(param0);
+    struct UnkSavStruct80 *res = FUN_02046528(param0);
     u16 *res2 = (u16 *)FUN_0204652C(param0);
     u8 *res3 = FUN_020316E0(1 - FUN_02031190());
     if (res3 == NULL)
@@ -286,7 +286,7 @@ THUMB_FUNC int FUN_0205FD70(struct UnkStruct_0204639C *param0)
         return 0;
     }
 
-    u16 *var = GetVarPointer((struct UnkSavStruct80 *)res, res2[1]);
+    u16 *var = GetVarPointer(res, res2[1]);
     switch (res2[0])
     {
     case 0:
@@ -294,11 +294,9 @@ THUMB_FUNC int FUN_0205FD70(struct UnkStruct_0204639C *param0)
         break;
     case 1:
         *var = MOD06_022446BC(res, res3);
-
         break;
     case 2:
         *var = MOD06_022446E0(res, res3);
-
         break;
     }
 
@@ -309,7 +307,7 @@ THUMB_FUNC int FUN_0205FD70(struct UnkStruct_0204639C *param0)
 
 THUMB_FUNC void FUN_0205FDDC(struct UnkStruct_0204639C *param0, u16 param1, u16 param2)
 {
-    struct UnkStruct_0204639C *res = FUN_02046528(param0);
+    struct UnkSavStruct80 *res = FUN_02046528(param0);
 
     u16 *ptr = AllocFromHeap(0xb, 2 * sizeof(u16));
     MI_CpuFill8(ptr, 0, 2 * sizeof(u16));

--- a/include/script.h
+++ b/include/script.h
@@ -28,7 +28,8 @@ struct UnkSavStruct80
     u8 padding[0x8];
     u32 unk08;
     struct SaveBlock2 *saveBlock2; //0xC
-    u8 padding2[0xC];
+    struct UnkStruct_0204639C *unk10;
+    u8 padding2[0x8];
     u32 *mapId; //0x1C
     u8 padding3[0x18];
     u32 unk38;

--- a/include/unk_0204639C.h
+++ b/include/unk_0204639C.h
@@ -1,6 +1,8 @@
 #ifndef GUARD_UNK_0204639C_H
 #define GUARD_UNK_0204639C_H
 
+#include "script.h"
+
 struct UnkStruct_0204639C;
 
 typedef BOOL (*UnkStruct_0204639C_cb)(struct UnkStruct_0204639C * );
@@ -13,18 +15,18 @@ struct UnkStruct_0204639C
     u32 * unkC;
     struct UnkStruct_0204639C * unk10;
     void * unk14;
-    struct UnkStruct_0204639C * unk18;
+    struct UnkSavStruct80 * unk18;
     u32 * unk1C;
 };
 
 extern void LoadOverlay_MODULE_05(void *);
-extern void FUN_020373D4(struct UnkStruct_0204639C *, u32, u32);
+extern void FUN_020373D4(struct UnkSavStruct80 *, u32, u32);
 extern BOOL FUN_020373AC(void *);
 extern BOOL FUN_0203739C(void *);
 extern BOOL FUN_020373C4(void *);
 
-struct UnkStruct_0204639C * FUN_0204639C(struct UnkStruct_0204639C * r5, UnkStruct_0204639C_cb r6, u32 * r7);
-void FUN_020463CC(struct UnkStruct_0204639C * r5, UnkStruct_0204639C_cb r4, u32 * r6);
+struct UnkStruct_0204639C * FUN_0204639C(struct UnkSavStruct80 * r5, UnkStruct_0204639C_cb r6, u32 * r7);
+void FUN_020463CC(struct UnkSavStruct80 * r5, UnkStruct_0204639C_cb r4, u32 * r6);
 void FUN_020463EC(struct UnkStruct_0204639C * r4, UnkStruct_0204639C_cb r1, u32 * r2);
 void FUN_0204640C(struct UnkStruct_0204639C * r4, UnkStruct_0204639C_cb r1, u32 * r2);
 BOOL FUN_02046420(struct UnkStruct_0204639C * r5);
@@ -37,6 +39,6 @@ void FUN_02046500(struct UnkStruct_0204639C * r6, u32 r5, u32 r4);
 u32 * FUN_0204652C(struct UnkStruct_0204639C * r0);
 u32 * FUN_02046530(struct UnkStruct_0204639C * r0);
 u32 FUN_02046534(struct UnkStruct_0204639C * r0);
-struct UnkStruct_0204639C * FUN_02046528(struct UnkStruct_0204639C *);
+struct UnkSavStruct80 * FUN_02046528(struct UnkStruct_0204639C *);
 
 #endif //GUARD_UNK_0204639C_H

--- a/include/unk_0205FA2C.h
+++ b/include/unk_0205FA2C.h
@@ -81,13 +81,13 @@ struct UnkCallbackStruct2_0205FA2C
 };
 
 THUMB_FUNC u32 FUN_0205FA2C(
-    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkStruct_0204639C *param1, u32 heap_id);
+    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkSavStruct80 *param1, u32 heap_id);
 THUMB_FUNC u32 FUN_0205FAD8(
-    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkStruct_0204639C *param1);
+    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkSavStruct80 *param1);
 THUMB_FUNC u32 FUN_0205FB34(
-    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkStruct_0204639C *param1, u32 heap_id);
+    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkSavStruct80 *param1, u32 heap_id);
 THUMB_FUNC u32 FUN_0205FBC0(
-    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkStruct_0204639C *param1);
+    struct UnkCallbackStruct1_0205FA2C *param0, struct UnkSavStruct80 *param1);
 THUMB_FUNC int FUN_0205FBE8(struct UnkStruct_0204639C *param0);
 THUMB_FUNC void FUN_0205FC50(struct UnkStruct_0204639C *param0,
     void **param1,
@@ -99,9 +99,9 @@ THUMB_FUNC void FUN_0205FC50(struct UnkStruct_0204639C *param0,
     u8 param7);
 
 THUMB_FUNC u32 FUN_0205FC9C(
-    struct UnkCallbackStruct2_0205FA2C *param0, struct UnkStruct_0204639C *param1);
+    struct UnkCallbackStruct2_0205FA2C *param0, struct UnkSavStruct80 *param1);
 THUMB_FUNC u32 FUN_0205FCC4(
-    struct UnkCallbackStruct2_0205FA2C *param0, struct UnkStruct_0204639C *param1);
+    struct UnkCallbackStruct2_0205FA2C *param0, struct UnkSavStruct80 *param1);
 THUMB_FUNC int FUN_0205FCE8(struct UnkStruct_0204639C *param0);
 THUMB_FUNC void FUN_0205FD38(struct UnkStruct_0204639C *param0, u16 param1, u16 param2, u16 param3);
 


### PR DESCRIPTION
A bunch of functions were thought to be returning/taking in an unk_204639c but they actually return/take an unksavstruct80. This fixes that, and also changes a couple of struct members, so this might be useful for scrcmd.