### PR TITLE
Rollback GitHub Actions to Ubuntu-Bionic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,22 +4,22 @@ on: [push, pull_request]
 
 env:
   LM_LICENSE_FILE: "$GITHUB_WORKSPACE/tools/mwccarm/license.dat"
-  CC: gcc-8
-  CXX: g++-8
+  CC: gcc-10
+  CXX: g++-10
   CALCROM_DISCORD_WEBHOOK_AVATAR_URL: "https://i.imgur.com/38BQHdd.png"
   CALCROM_DISCORD_WEBHOOK_USERNAME: OK
   CALCROM_WEBHOOK_URL: ${{ secrets.WEBHOOKURL }}
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Update and Install Software
         run: |
           sudo apt update
           sudo ACCEPT_EULA=Y apt -y --fix-missing --allow-downgrades upgrade
-          sudo apt -y --allow-downgrades install g++-8-multilib linux-libc-dev binutils-arm-none-eabi p7zip-full pkg-config
+          sudo apt -y --allow-downgrades install g++-10-multilib linux-libc-dev binutils-arm-none-eabi p7zip-full pkg-config
           sudo dpkg --add-architecture i386
           wget -qO - https://dl.winehq.org/wine-builds/winehq.key | sudo apt-key add -
           sudo add-apt-repository ppa:cybermax-dexter/sdl2-backport

--- a/tools/bin2obj/bin2obj.cpp
+++ b/tools/bin2obj/bin2obj.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 #include <fstream>
+#include <cstring>
 extern "C" {
 #include "elf.h"
 }
@@ -188,27 +189,28 @@ int main(int argc, char** argv) {
     binfile.seekg(0);
 
     // Elf header
-    Elf32_Ehdr ehdr = {
-        .e_ident = {
-            ELFMAG0,        // EI_MAG0
-            ELFMAG1,        // EI_MAG1
-            ELFMAG2,        // EI_MAG2
-            ELFMAG3,        // EI_MAG3
-            ELFCLASS32,     // EI_CLASS
-            endian,         // EI_DATA
-            EV_CURRENT,     // EI_VERSION
-            ELFOSABI_NONE,  // EI_OSABI
-            0,              // EI_ABIVERSION
-        },
-        .e_type = ET_REL,
-        .e_machine = proc,
-        .e_version = EV_CURRENT,
-        .e_shoff = sizeof(Elf32_Ehdr),
-        .e_ehsize = sizeof(Elf32_Ehdr),
-        .e_shentsize = sizeof(Elf32_Shdr),
-        .e_shnum = 5,
-        .e_shstrndx = 1,
+    Elf32_Ehdr ehdr;
+
+    static const unsigned char _eident[EI_NIDENT] {
+        ELFMAG0,        // EI_MAG0
+        ELFMAG1,        // EI_MAG1
+        ELFMAG2,        // EI_MAG2
+        ELFMAG3,        // EI_MAG3
+        ELFCLASS32,     // EI_CLASS
+        endian,         // EI_DATA
+        EV_CURRENT,     // EI_VERSION
+        ELFOSABI_NONE,  // EI_OSABI
+        0,              // EI_ABIVERSION
     };
+    memcpy(ehdr.e_ident, _eident, EI_NIDENT);
+    ehdr.e_type = ET_REL;
+    ehdr.e_machine = proc;
+    ehdr.e_version = EV_CURRENT;
+    ehdr.e_shoff = sizeof(Elf32_Ehdr);
+    ehdr.e_ehsize = sizeof(Elf32_Ehdr);
+    ehdr.e_shentsize = sizeof(Elf32_Shdr);
+    ehdr.e_shnum = 5;
+    ehdr.e_shstrndx = 1;
 
     // Five sections: NULL, user section, symtab, strtab, shstrtab
     Elf32_Shdr shdr[5] = {};

--- a/tools/msgenc/Makefile
+++ b/tools/msgenc/Makefile
@@ -8,12 +8,11 @@ endif
 DEPDIR := .deps
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.d
 
-define SRCS :=
-	msgenc.cpp
-	MessagesConverter.cpp
-	MessagesDecoder.cpp
+SRCS := \
+	msgenc.cpp \
+	MessagesConverter.cpp \
+	MessagesDecoder.cpp \
 	MessagesEncoder.cpp
-endef
 
 OBJS := $(SRCS:%.cpp=%.o)
 


### PR DESCRIPTION
A dependency issue surfaced on 23 Nov 2021 regarding winehq-stable:focal. As the issue does not currently affect bionic, this reversion is necessary for the continued use of GitHub Actions with this project.