### PR TITLE
Explicitly link zlib in nitrogfx Makefile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,6 @@ Building the ROM requires the following packages:
 * wine (to run the mwcc executables)
 * python3 (for asm preprocessor)
 * libpng-devel (libpng-dev on Ubuntu)
-* zlib-devel (installed by libpng; zlib1g-dev on Ubuntu)
 * pkg-config
 * pugixml (libpugixml-dev on Ubuntu)
 
@@ -51,7 +50,6 @@ You will still require the following packages:
 * git
 * build-essentials
 * libpng-devel
-* zlib-devel
 * pkg-config
 * pugixml
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,6 +21,7 @@ Building the ROM requires the following packages:
 * wine (to run the mwcc executables)
 * python3 (for asm preprocessor)
 * libpng-devel (libpng-dev on Ubuntu)
+* zlib-devel (installed by libpng; zlib1g-dev on Ubuntu)
 * pkg-config
 * pugixml (libpugixml-dev on Ubuntu)
 
@@ -50,6 +51,7 @@ You will still require the following packages:
 * git
 * build-essentials
 * libpng-devel
+* zlib-devel
 * pkg-config
 * pugixml
 

--- a/tools/nitrogfx/Makefile
+++ b/tools/nitrogfx/Makefile
@@ -1,14 +1,18 @@
 CC = gcc
 
 HAVE_LIBPNG := $(shell pkg-config libpng; echo $?)
+HAVE_ZLIB := $(shell pkg-config zlib; echo $?)
 
 ifeq ($(HAVE_LIBPNG),1)
 $(error No package 'libpng' found)
 endif
+ifeq ($(HAVE_ZLIB),1)
+$(error No package 'zlib' found)
+endif
 
-CFLAGS = -Wall -Wextra -Werror -Wno-sign-compare -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK $(shell pkg-config --cflags libpng)
+CFLAGS = -Wall -Wextra -Werror -Wno-sign-compare -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK $(shell pkg-config --cflags libpng zlib)
 
-LIBS = $(shell pkg-config --libs libpng)
+LIBS = $(shell pkg-config --libs libpng zlib)
 
 SRCS = main.c convert_png.c gfx.c jasc_pal.c lz.c rl.c util.c font.c huff.c json.c cJSON.c
 OBJS = $(SRCS:%.c=%.o)

--- a/tools/nitrogfx/Makefile
+++ b/tools/nitrogfx/Makefile
@@ -1,13 +1,9 @@
 CC = gcc
 
 HAVE_LIBPNG := $(shell pkg-config libpng; echo $?)
-HAVE_ZLIB := $(shell pkg-config zlib; echo $?)
 
 ifeq ($(HAVE_LIBPNG),1)
 $(error No package 'libpng' found)
-endif
-ifeq ($(HAVE_ZLIB),1)
-$(error No package 'zlib' found)
 endif
 
 CFLAGS = -Wall -Wextra -Werror -Wno-sign-compare -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK $(shell pkg-config --cflags libpng zlib)


### PR DESCRIPTION
`nitrogfx` wouldn't compile for me on MYS2 unless I told it to link `zlib` in its `Makefile`.

`zlib` is a dependency of `libpng` and normally comes installed with it in the package manager, meaning this won't change the normal build process at all, but it has to be installed manually if compiling the library from source like required for MSYS2.