### PR TITLE
synchronise bg_window.c with heartgold

### DIFF
--- a/arm9/global.inc
+++ b/arm9/global.inc
@@ -1109,8 +1109,8 @@
 .extern GetWindowHeight
 .extern GetWindowX
 .extern GetWindowY
-.extern MoveWindowX
-.extern MoveWindowY
+.extern SetWindowX
+.extern SetWindowY
 .extern SetWindowPaletteNum
 .extern LoadCharacterDataFromFile
 .extern LoadPaletteDataFromFile

--- a/arm9/global.inc
+++ b/arm9/global.inc
@@ -1066,7 +1066,7 @@
 .extern BgFillTilemapBufferAndSchedule
 .extern BgGetCharPtr
 .extern GetBgTilemapBuffer
-.extern GetBgAffineRotation
+.extern GetBgRotation
 .extern GetBgPriority
 .extern BlitBitmapRect4Bit
 .extern FillBitmapRect8Bit

--- a/arm9/lib/NitroSDK/include/GX_bgcnt.h
+++ b/arm9/lib/NitroSDK/include/GX_bgcnt.h
@@ -169,12 +169,10 @@ typedef enum
 }
 GXBGScrSizeLargeBmp;
 
-typedef enum
-{
+typedef enum {
     GX_BG_COLORMODE_16 = 0,
     GX_BG_COLORMODE_256 = 1
-}
-GXBGColorMode;
+} GXBGColorMode;
 
 typedef enum
 {

--- a/arm9/lib/NitroSDK/include/MI_uncompress.h
+++ b/arm9/lib/NitroSDK/include/MI_uncompress.h
@@ -1,7 +1,13 @@
 #ifndef POKEDIAMOND_MI_UNCOMPRESS_H
 #define POKEDIAMOND_MI_UNCOMPRESS_H
 
+#include "nitro/types.h"
+
 void MIi_UncompressBackward(void * bottom);
 void MI_UncompressLZ8(register const void *srcp, register void *destp);
+
+inline u32 MI_GetUncompressedSize(const void *srcp) {
+    return (*(u32 *)srcp >> 8);
+}
 
 #endif //POKEDIAMOND_MI_UNCOMPRESS_H

--- a/arm9/overlays/59/include/ov59_Intro.h
+++ b/arm9/overlays/59/include/ov59_Intro.h
@@ -126,7 +126,7 @@ void ov59_LoadCharDataFromIndex(ov59_IntroOverlayData *data);
 void ov59_LoadSubScrnData(ov59_IntroOverlayData *data);
 void ov59_DrawMunchlax(ov59_IntroOverlayData *data);
 void ov59_LoadPokeballButton(ov59_IntroOverlayData *data);
-BOOL ov59_MoveSprite(ov59_IntroOverlayData *data, u32 layer, u32 param2);
+BOOL ov59_MoveSprite(ov59_IntroOverlayData *data, enum GFBgLayer layer, u32 param2);
 void ov59_ResetPlayerAnimation(ov59_IntroOverlayData *data);
 void ov59_AnimatePlayerSprite(ov59_IntroOverlayData *data);
 void ov59_DisableBlend(ov59_IntroOverlayData *data);

--- a/arm9/overlays/59/src/ov59_Intro.c
+++ b/arm9/overlays/59/src/ov59_Intro.c
@@ -33,66 +33,66 @@ extern void sub_0200E3A0(PMLCDTarget, int);
 const struct WindowTemplate ov59_021D9DB8 =
     {
         .bgId = GF_BG_LYR_MAIN_0,
-        .tilemapLeft = 2,
-        .tilemapTop = 19,
+        .left = 2,
+        .top = 19,
         .width = 27,
         .height = 4,
-        .paletteNum = 6,
+        .palette = 6,
         .baseTile = 877,
     };
 
 const struct WindowTemplate ov59_021D9DA8 =
     {
         .bgId = GF_BG_LYR_MAIN_0,
-        .tilemapLeft = 2,
-        .tilemapTop = 3,
+        .left = 2,
+        .top = 3,
         .width = 6,
         .height = 4,
-        .paletteNum = 5,
+        .palette = 5,
         .baseTile = 853,
     };
 
 const struct WindowTemplate ov59_021D9DB0 =
     {
         .bgId = GF_BG_LYR_MAIN_0,
-        .tilemapLeft = 1,
-        .tilemapTop = 3,
+        .left = 1,
+        .top = 3,
         .width = 16,
         .height = 6,
-        .paletteNum = 5,
+        .palette = 5,
         .baseTile = 781,
     };
 
 const struct WindowTemplate ov59_021D9D90 =
     {
         .bgId = GF_BG_LYR_MAIN_0,
-        .tilemapLeft = 8,
-        .tilemapTop = 0,
+        .left = 8,
+        .top = 0,
         .width = 24,
         .height = 24,
-        .paletteNum = 5,
+        .palette = 5,
         .baseTile = 301,
     };
 
 const struct WindowTemplate ov59_021D9D98 =
     {
         .bgId = GF_BG_LYR_MAIN_0,
-        .tilemapLeft = 4,
-        .tilemapTop = 0,
+        .left = 4,
+        .top = 0,
         .width = 24,
         .height = 24,
-        .paletteNum = 5,
+        .palette = 5,
         .baseTile = 301,
     };
 
 const struct WindowTemplate ov59_021D9DA0 =
     {
         .bgId = GF_BG_LYR_MAIN_0,
-        .tilemapLeft = 2,
-        .tilemapTop = 3,
+        .left = 2,
+        .top = 3,
         .width = 14,
         .height = 10,
-        .paletteNum = 5,
+        .palette = 5,
         .baseTile = 737,
     };
 
@@ -956,7 +956,7 @@ BOOL ov59_DisplayControlAdventureMessage(ov59_IntroOverlayData *data, u32 msgNo,
             {
                 template = ov59_021D9D98;
                 u32 count = sub_02002F90(data->string);
-                template.tilemapTop = (u8)(12 - count);
+                template.top = (u8)(12 - count);
                 template.height = (u8)(count * 2);
                 AddWindow(data->bgConfig, &data->window, &template);
                 FillWindowPixelRect(&data->window, 0, 0, 0, 192, 192);
@@ -965,7 +965,7 @@ BOOL ov59_DisplayControlAdventureMessage(ov59_IntroOverlayData *data, u32 msgNo,
             else
             {
                 template = ov59_021D9D90;
-                template.tilemapTop = (u8)tilemapTop;
+                template.top = (u8)tilemapTop;
                 template.height = (u8)height;
                 AddWindow(data->bgConfig, &data->window, &template);
                 FillWindowPixelRect(&data->window, 0, 0, 0, 192, 192);

--- a/arm9/overlays/59/src/ov59_Intro.c
+++ b/arm9/overlays/59/src/ov59_Intro.c
@@ -1275,7 +1275,7 @@ void ov59_LoadPokeballButton(ov59_IntroOverlayData *data)
     GfGfxLoader_LoadCharData(NARC_DEMO_INTRO_INTRO, NARC_intro_pokeball_button_1_NCGR, data->bgConfig, GF_BG_LYR_SUB_2, 0x20, 0, FALSE, data->heapId);
 }
 
-BOOL ov59_MoveSprite(ov59_IntroOverlayData *data, u32 layer, u32 param2)
+BOOL ov59_MoveSprite(ov59_IntroOverlayData *data, enum GFBgLayer layer, u32 param2)
 {
     BOOL ret = FALSE;
     if (param2 == 0)

--- a/arm9/overlays/59/src/ov59_TV.c
+++ b/arm9/overlays/59/src/ov59_TV.c
@@ -23,11 +23,11 @@ extern BOOL IsPaletteFadeFinished(void);
 const struct WindowTemplate ov59_021DA04C =
     {
         .bgId = GF_BG_LYR_MAIN_2,
-        .tilemapLeft = 0,
-        .tilemapTop = 0,
+        .left = 0,
+        .top = 0,
         .width = 32,
         .height = 24,
-        .paletteNum = 0x01,
+        .palette = 1,
         .baseTile = 1,
     };
 

--- a/arm9/overlays/75/asm/overlay_75.s
+++ b/arm9/overlays/75/asm/overlay_75.s
@@ -6707,7 +6707,7 @@ ov75_021EA0CC: ; 0x021EA0CC
 	ldr r0, [r4]
 	add r5, r1, #0
 	mov r1, #7
-	bl GetBgAffineRotation
+	bl GetBgRotation
 	lsl r0, r0, #0x10
 	asr r0, r0, #0x10
 	add r0, r0, r5

--- a/arm9/overlays/83/asm/overlay_83.s
+++ b/arm9/overlays/83/asm/overlay_83.s
@@ -1477,11 +1477,11 @@ _0222E104:
 	beq _0222E188
 	ldr r0, [sp, #0x2c]
 	mov r1, #3
-	bl MoveWindowX
+	bl SetWindowX
 	lsl r1, r5, #0x18
 	ldr r0, [sp, #0x2c]
 	lsr r1, r1, #0x18
-	bl MoveWindowY
+	bl SetWindowY
 	ldr r2, [sp, #0x54]
 	ldr r3, [sp, #0x58]
 	lsl r2, r2, #0x10
@@ -23228,7 +23228,7 @@ _02238A8A:
 	add r0, r1, #0
 	lsl r1, r6, #0x18
 	lsr r1, r1, #0x18
-	bl MoveWindowX
+	bl SetWindowX
 _02238A9C:
 	mov r0, #0
 	mvn r0, r0
@@ -23237,7 +23237,7 @@ _02238A9C:
 	lsl r1, r5, #0x18
 	ldr r0, [r4, #0x10]
 	lsr r1, r1, #0x18
-	bl MoveWindowY
+	bl SetWindowY
 _02238AAE:
 	ldr r1, [sp, #0x28]
 	add r0, r4, #0

--- a/arm9/src/GX_layers.c
+++ b/arm9/src/GX_layers.c
@@ -40,7 +40,7 @@ void GX_DisableEngineALayers()
     EngineA_DISPCNT_LayerMask = 0;
 }
 
-void GX_EngineAToggleLayers(u32 layer_mask, GX_LayerToggle layer_toggle)
+void GX_EngineAToggleLayers(u32 layer_mask, GXLayerToggle layer_toggle)
 {
     if (layer_toggle == GX_LAYER_TOGGLE_ON)
     {
@@ -71,7 +71,7 @@ void GX_DisableEngineBLayers()
     EngineB_DISPCNT_LayerMask = 0;
 }
 
-void GX_EngineBToggleLayers(u32 layer_mask, GX_LayerToggle layer_toggle)
+void GX_EngineBToggleLayers(u32 layer_mask, GXLayerToggle layer_toggle)
 {
     if (layer_toggle == GX_LAYER_TOGGLE_ON)
     {

--- a/arm9/src/communication_error.c
+++ b/arm9/src/communication_error.c
@@ -15,11 +15,11 @@ extern void sub_0200E3A0(BOOL set_brightness_on_bottom_screen, s32);
 
 static const struct WindowTemplate sCommunicationErrorWindowTemplate = {
     .bgId = GF_BG_LYR_MAIN_0,
-    .tilemapLeft = 3,
-    .tilemapTop = 3,
+    .left = 3,
+    .top = 3,
     .width = 26,
     .height = 18,
-    .paletteNum = 0x01,
+    .palette = 1,
     .baseTile = 0x23,
 };
 

--- a/arm9/src/error_message_reset.c
+++ b/arm9/src/error_message_reset.c
@@ -15,11 +15,11 @@
 
 static const struct WindowTemplate sErrorMessageWindowTemplate = {
     .bgId = GF_BG_LYR_MAIN_0,
-    .tilemapLeft = 3,
-    .tilemapTop = 3,
+    .left = 3,
+    .top = 3,
     .width = 26,
     .height = 18,
-    .paletteNum = 1,
+    .palette = 1,
     .baseTile = 0x23
 };
 

--- a/arm9/src/render_window.c
+++ b/arm9/src/render_window.c
@@ -326,7 +326,7 @@ void sub_0200D18C(struct Window *window, u16 fill_value)
     u8 bg_id = GetWindowBgId(window);
 
     void *ptr = AllocFromHeap(heapId, 0x180);
-    void *charptr = BgGetCharPtr(bg_id);
+    void *charptr = BgGetCharPtr((u8)bg_id);
 
     NNSG2dCharacterData *pCharData;
     void *st30;
@@ -344,7 +344,7 @@ void sub_0200D18C(struct Window *window, u16 fill_value)
     }
 
     BlitRect4Bit(st30, 4, 0, 12, 0x30, ptr, 12, 0x30, 1, 0, 12, 0x30);
-    BG_LoadCharTilesData(window->bgConfig, bg_id, ptr, 0x180, (u32)(fill_value + 18));
+    BG_LoadCharTilesData(window->bgConfig, (u8)bg_id, ptr, 0x180, (u32)(fill_value + 18));
     sub_02002840(fill_value);
     FreeToHeap(st2c);
     FreeToHeap(ptr);

--- a/arm9/src/save_data_read_error.c
+++ b/arm9/src/save_data_read_error.c
@@ -15,11 +15,11 @@ extern void sub_0200E3A0(BOOL set_brightness_on_bottom_screen, s32);
 
 static const struct WindowTemplate sSaveDataReadErrorWindowTemplate = {
     .bgId = GF_BG_LYR_MAIN_0,
-    .tilemapLeft = 3,
-    .tilemapTop = 3,
+    .left = 3,
+    .top = 3,
     .width = 26,
     .height = 18,
-    .paletteNum = 0x01,
+    .palette = 1,
     .baseTile = 0x23,
 };
 

--- a/arm9/src/save_data_write_error.c
+++ b/arm9/src/save_data_write_error.c
@@ -15,11 +15,11 @@ extern void sub_0200E3A0(BOOL set_brightness_on_bottom_screen, s32);
 
 static const struct WindowTemplate sSaveDataWriteErrorWindowTemplate = {
     .bgId = GF_BG_LYR_MAIN_0,
-    .tilemapLeft = 3,
-    .tilemapTop = 3,
+    .left = 3,
+    .top = 3,
     .width = 26,
     .height = 18,
-    .paletteNum = 0x01,
+    .palette = 1,
     .baseTile = 0x23,
 };
 

--- a/arm9/src/wfc_user_info_warning.c
+++ b/arm9/src/wfc_user_info_warning.c
@@ -20,11 +20,11 @@ extern void sub_0200E3A0(BOOL set_brightness_on_bottom_screen, s32);
 
 static const struct WindowTemplate sWFCWarningMsgWindowTemplate = {
     .bgId = GF_BG_LYR_MAIN_0,
-    .tilemapLeft = 3,
-    .tilemapTop = 3,
+    .left = 3,
+    .top = 3,
     .width = 26,
     .height = 18,
-    .paletteNum = 0x01,
+    .palette = 1,
     .baseTile = 0x23,
 };
 

--- a/include/GX_layers.h
+++ b/include/GX_layers.h
@@ -9,7 +9,7 @@
 typedef enum {
     GX_LAYER_TOGGLE_OFF,
     GX_LAYER_TOGGLE_ON,
-} GX_LayerToggle;
+} GXLayerToggle;
 
 struct GraphicsBanks
 {
@@ -25,19 +25,19 @@ struct GraphicsBanks
     s32 texpltt;
 };
 
-struct GraphicsModes {
+typedef struct GraphicsModes {
     GXDispMode dispMode;
     GXBGMode bgMode;
     GXBGMode subMode;
     GXBG0As _2d3dMode;
-};
+} GraphicsModes;
 
 void GX_SetBanks(const struct GraphicsBanks *banks);
 void GX_DisableEngineALayers(void);
-void GX_EngineAToggleLayers(u32 layer_mask, GX_LayerToggle layer_toggle);
+void GX_EngineAToggleLayers(u32 layer_mask, GXLayerToggle layer_toggle);
 void GX_SetEngineALayers(u32 layer_mask);
 void GX_DisableEngineBLayers(void);
-void GX_EngineBToggleLayers(u32 layer_mask, GX_LayerToggle layer_toggle);
+void GX_EngineBToggleLayers(u32 layer_mask, GXLayerToggle layer_toggle);
 void GX_BothDispOn(void);
 void GX_SwapDisplay(void);
 u32 GX_GetEngineALayers(void);

--- a/include/bg_window.h
+++ b/include/bg_window.h
@@ -1,5 +1,5 @@
-#ifndef POKEDIAMOND_UNK_02016B94_H
-#define POKEDIAMOND_UNK_02016B94_H
+#ifndef POKEDIAMOND_BG_WINDOW_H
+#define POKEDIAMOND_BG_WINDOW_H
 
 #include "NNS_g2d.h"
 #include "global.h"
@@ -10,8 +10,7 @@
 #include "heap.h"
 #include "math_util.h"
 
-typedef struct BgTemplate
-{
+typedef struct BgTemplate {
     u32 x;
     u32 y;
     u32 bufferSize;
@@ -61,8 +60,7 @@ typedef struct Bitmap {
     u16 height;
 } Bitmap;
 
-typedef struct WindowTemplate
-{
+typedef struct WindowTemplate {
     u8 bgId;
     u8 left;
     u8 top;
@@ -72,8 +70,7 @@ typedef struct WindowTemplate
     u16 baseTile;
 } WindowTemplate;
 
-typedef struct Window
-{
+typedef struct Window {
     BgConfig *bgConfig;
     u8 bgId;
     u8 tilemapLeft;
@@ -91,14 +88,12 @@ enum GFScreen {
     SCREEN_SUB  = 1,
 };
 
-enum GFBppMode
-{
+enum GFBppMode {
     GF_BG_CLR_4BPP = 0,
     GF_BG_CLR_8BPP,
 };
 
-enum GFBgLayer
-{
+enum GFBgLayer {
     GF_BG_LYR_MAIN_0 = 0,
     GF_BG_LYR_MAIN_1,
     GF_BG_LYR_MAIN_2,
@@ -168,8 +163,7 @@ enum GFBgCntSet {
     GF_BG_CNT_SET_CHAR_BASE,
 };
 
-enum GFBgScreenSize
-{
+enum GFBgScreenSize {
     GF_BG_SCR_SIZE_128x128 = 0,
     GF_BG_SCR_SIZE_256x256,
     GF_BG_SCR_SIZE_256x512,
@@ -178,8 +172,7 @@ enum GFBgScreenSize
     GF_BG_SCR_SIZE_1024x1024
 };
 
-enum BgPosAdjustOp
-{
+enum BgPosAdjustOp {
     // Text layers
     BG_POS_OP_SET_X = 0,
     BG_POS_OP_ADD_X,
@@ -272,27 +265,21 @@ void BlitBitmapRect(Window *window, void *src, u16 srcX, u16 srcY, u16 srcWidth,
 void FillWindowPixelRect(Window *window, u8 fillValue, u16 x, u16 y, u16 width, u16 height);
 void CopyGlyphToWindow(Window *window, u8 *glyphPixels, u16 srcWidth, u16 srcHeight, u16 destX, u16 destY, u16 table);
 void ScrollWindow(Window *window, u8 direction, u8 y, u8 fillValue);
-void ScrollWindow8bpp(Window *window, u32 param1, u8 param2, u8 fillValue);
 u8 GetWindowBgId(Window *window);
 u8 GetWindowWidth(Window *window);
 u8 GetWindowHeight(Window *window);
 u8 GetWindowX(Window *window);
 u8 GetWindowY(Window *window);
-void MoveWindowX(Window *window, u8 x);
-void MoveWindowY(Window *window, u8 y);
+void SetWindowX(Window *window, u8 x);
+void SetWindowY(Window *window, u8 y);
 void SetWindowPaletteNum(Window *window, u8 paletteNum);
-NNSG2dCharacterData * LoadCharacterDataFromFile(void **char_ret, HeapID heapId, const char *path);
-NNSG2dPaletteData * LoadPaletteDataFromFile(void **pltt_ret, HeapID heapId, const char *path);
+NNSG2dCharacterData *LoadCharacterDataFromFile(void **char_ret, HeapID heapId, const char *path);
+NNSG2dPaletteData *LoadPaletteDataFromFile(void **pltt_ret, HeapID heapId, const char *path);
 void DoScheduledBgGpuUpdates(BgConfig *bgConfig);
-void DoScheduledBgTilemapBufferTransfers(BgConfig *bgConfig);
 void ScheduleBgTilemapBufferTransfer(BgConfig *bgConfig, u8 bgId);
-void ApplyScheduledBgPosUpdate(BgConfig *bgConfig);
-void ScheduleSetBgPosText(BgConfig *bgConfig, u8 bgId, u32 op, fx32 value);
-void ScheduleSetBgAffineRotation(BgConfig *bgConfig, u8 bgId, u32 op, u16 value);
-void Bg_SetAffineRotation(Background *bg, u32 op, u16 val);
-void ScheduleSetBgAffinePos(BgConfig *bgConfig, u8 bgId, u32 op, fx32 value);
-void Bg_SetAffinePos(Background *bg, u32 op, fx32 val);
-u32 DoesPixelAtScreenXYMatchPtrVal(BgConfig *bgConfig, u8 bgId, u8 x, u8 y, u16 *src);
-void ApplyFlipFlagsToTile(BgConfig *bgConfig, u8 flag, u8 *src);
+void ScheduleSetBgPosText(BgConfig *bgConfig, u8 bgId, enum BgPosAdjustOp op, fx32 value);
+void ScheduleSetBgAffineRotation(BgConfig *bgConfig, u8 bgId, enum BgPosAdjustOp op, u16 value);
+void ScheduleSetBgAffinePos(BgConfig *bgConfig, u8 bgId, enum BgPosAdjustOp op, fx32 value);
+BOOL DoesPixelAtScreenXYMatchPtrVal(BgConfig *bgConfig, u8 bgId, u8 x, u8 y, u16 *src);
 
-#endif // POKEDIAMOND_UNK_02016B94_H
+#endif // POKEDIAMOND_BG_WINDOW_H

--- a/include/bg_window.h
+++ b/include/bg_window.h
@@ -61,16 +61,16 @@ typedef struct Bitmap {
     u16 height;
 } Bitmap;
 
-struct WindowTemplate
+typedef struct WindowTemplate
 {
     u8 bgId;
-    u8 tilemapLeft;
-    u8 tilemapTop;
+    u8 left;
+    u8 top;
     u8 width;
     u8 height;
-    u8 paletteNum;
+    u8 palette;
     u16 baseTile;
-};
+} WindowTemplate;
 
 typedef struct Window
 {
@@ -111,6 +111,7 @@ enum GFBgLayer
     GF_BG_LYR_SUB_CNT = 4,
     GF_BG_LYR_MAIN_FIRST = GF_BG_LYR_MAIN_0,
     GF_BG_LYR_SUB_FIRST = GF_BG_LYR_SUB_0,
+    GF_BG_LYR_MAX = 8,
 
     GF_BG_LYR_MAIN_0_F = 1 << (GF_BG_LYR_MAIN_0 - GF_BG_LYR_MAIN_FIRST),
     GF_BG_LYR_MAIN_1_F = 1 << (GF_BG_LYR_MAIN_1 - GF_BG_LYR_MAIN_FIRST),
@@ -158,10 +159,10 @@ enum GFBgType {
     GF_BG_TYPE_TEXT = 0,
     GF_BG_TYPE_AFFINE,
     GF_BG_TYPE_256x16PLTT,
+    GF_BG_TYPE_MAX,
 };
 
-enum GFBgCntSet
-{
+enum GFBgCntSet {
     GF_BG_CNT_SET_COLOR_MODE = 0,
     GF_BG_CNT_SET_SCREEN_BASE,
     GF_BG_CNT_SET_CHAR_BASE,
@@ -251,89 +252,35 @@ void FillBitmapRect8Bit(const Bitmap *surface, u16 x, u16 y, u16 width, u16 heig
 Window *AllocWindows(HeapID heapId, s32 num);
 void InitWindow(Window *window);
 BOOL WindowIsInUse(const Window *window);
-void AddWindowParameterized(BgConfig *param0,
-                            struct Window *window,
-                            u8 bgId,
-                            u8 tilemapLeft,
-                            u8 tilemapTop,
-                            u8 width,
-                            u8 height,
-                            u8 paletteNum,
-                            u16 baseTile);
-void AddTextWindowTopLeftCorner(BgConfig *param0,
-                                struct Window *window,
-                                u8 width,
-                                u8 height,
-                                u16 baseTile,
-                                u8 paletteNum);
-void AddWindow(BgConfig *bgConfig,
-               struct Window *window,
-               const struct WindowTemplate *template);
-void RemoveWindow(struct Window *window);
-void WindowArray_Delete(struct Window *windows, int count);
-void CopyWindowToVram(struct Window *window);
-void ScheduleWindowCopyToVram(struct Window *window);
-void PutWindowTilemap(struct Window *window);
-void PutWindowTilemapRectAnchoredTopLeft(struct Window *window, u8 width, u8 height);
-void ClearWindowTilemap(struct Window *window);
-void PutWindowTilemap_TextMode(struct Window *param0);
-void PutWindowTilemap_AffineMode(struct Window *window);
-void ClearWindowTilemapText(struct Window *window);
-void ClearWindowTilemapAffine(struct Window *window);
-void CopyWindowToVram_TextMode(struct Window *window);
-void ScheduleWindowCopyToVram_TextMode(struct Window *window);
-void CopyWindowToVram_AffineMode(struct Window *window);
-void ScheduleWindowCopyToVram_AffineMode(struct Window *window);
-void CopyWindowPixelsToVram_TextMode(struct Window *window);
-void ClearWindowTilemapAndCopyToVram(struct Window *window);
-void ClearWindowTilemapAndScheduleTransfer(struct Window *window);
-void ClearWindowTilemapAndCopyToVram_TextMode(struct Window *window);
-void ClearWindowTilemapAndScheduleTransfer_TextMode(struct Window *window);
-void ClearWindowTilemapAndCopyToVram_AffineMode(struct Window *window);
-void ClearWindowTilemapAndScheduleTransfer_AffineMode(struct Window *window);
-void FillWindowPixelBuffer(struct Window *window, u8 param1);
-void BlitBitmapRectToWindow(struct Window *window,
-    const void *src,
-    u16 srcX,
-    u16 srcY,
-    u16 srcWidth,
-    u16 srcHeight,
-    u16 dstX,
-    u16 dstY,
-    u16 dstWidth,
-    u16 dstHeight);
-void BlitBitmapRect(struct Window *window,
-    void *param1,
-    u16 param2,
-    u16 param3,
-    u16 param4,
-    u16 param5,
-    u16 param6,
-    u16 param7,
-    u16 param8,
-    u16 param9,
-    u16 param10);
-void FillWindowPixelRect(struct Window *window, u8 fillValue, u16 x, u16 y, u16 width, u16 height);
-void CopyGlyphToWindow(
-    struct Window * window,
-    u8 *glyphPixels,
-    u16 srcWidth,
-    u16 srcHeight,
-    u16 width,
-    u16 height,
-    u16 glyph
-);
-void ScrollWindow(struct Window *window, u32 param1, u8 param2, u8 param3);
-void ScrollWindow4bpp(struct Window *window, u32 param1, u8 param2, u8 fillValue);
-void ScrollWindow8bpp(struct Window *window, u32 param1, u8 param2, u8 fillValue);
-u8 GetWindowBgId(struct Window *window);
-u8 GetWindowWidth(struct Window *window);
-u8 GetWindowHeight(struct Window *window);
-u8 GetWindowX(struct Window *window);
-u8 GetWindowY(struct Window *window);
-void MoveWindowX(struct Window *window, u8 x);
-void MoveWindowY(struct Window *window, u8 y);
-void SetWindowPaletteNum(struct Window *window, u8 paletteNum);
+void AddWindowParameterized(BgConfig *bgConfig, Window *window, u8 bgId, u8 x, u8 y, u8 width, u8 height, u8 paletteNum, u16 baseTile);
+void AddTextWindowTopLeftCorner(BgConfig *bgConfig, Window *window, u8 width, u8 height, u16 baseTile, u8 paletteNum);
+void AddWindow(BgConfig *bgConfig, Window *window, const WindowTemplate *template);
+void RemoveWindow(Window *window);
+void WindowArray_Delete(Window *windows, s32 count);
+void CopyWindowToVram(Window *window);
+void ScheduleWindowCopyToVram(Window *window);
+void PutWindowTilemap(Window *window);
+void PutWindowTilemapRectAnchoredTopLeft(Window *window, u8 width, u8 height);
+void ClearWindowTilemap(Window *window);
+void PutWindowTilemap_AffineMode(Window *window);
+void CopyWindowPixelsToVram_TextMode(Window *window);
+void ClearWindowTilemapAndCopyToVram(Window *window);
+void ClearWindowTilemapAndScheduleTransfer(Window *window);
+void FillWindowPixelBuffer(Window *window, u8 fillValue);
+void BlitBitmapRectToWindow(Window *window, void *src, u16 srcX, u16 srcY, u16 srcWidth, u16 srcHeight, u16 destX, u16 destY, u16 destWidth, u16 destHeight);
+void BlitBitmapRect(Window *window, void *src, u16 srcX, u16 srcY, u16 srcWidth, u16 srcHeight, u16 destX, u16 destY, u16 destWidth, u16 destHeight, u16 colorKey);
+void FillWindowPixelRect(Window *window, u8 fillValue, u16 x, u16 y, u16 width, u16 height);
+void CopyGlyphToWindow(Window *window, u8 *glyphPixels, u16 srcWidth, u16 srcHeight, u16 destX, u16 destY, u16 table);
+void ScrollWindow(Window *window, u8 direction, u8 y, u8 fillValue);
+void ScrollWindow8bpp(Window *window, u32 param1, u8 param2, u8 fillValue);
+u8 GetWindowBgId(Window *window);
+u8 GetWindowWidth(Window *window);
+u8 GetWindowHeight(Window *window);
+u8 GetWindowX(Window *window);
+u8 GetWindowY(Window *window);
+void MoveWindowX(Window *window, u8 x);
+void MoveWindowY(Window *window, u8 y);
+void SetWindowPaletteNum(Window *window, u8 paletteNum);
 NNSG2dCharacterData * LoadCharacterDataFromFile(void **char_ret, HeapID heapId, const char *path);
 NNSG2dPaletteData * LoadPaletteDataFromFile(void **pltt_ret, HeapID heapId, const char *path);
 void DoScheduledBgGpuUpdates(BgConfig *bgConfig);


### PR DESCRIPTION
I think I genuinely hate graphics programming, this is the worst part of the rom, even with all the shit I've seen and everything that doesn't make sense, this fucking file is the worst out of all of them. I genuinely hate this shit, it's actually frustrating, sometimes the bg id is a u32 and sometimes it's a u8, the enum doesn't work if it's a u8, and some parts don't match, and some parts don't match if everything is a u32, I don't get why they didn't just put it fully as one or the other, I once again question the mental capacity of the people who wrote this file in the first place, and question whether they were on drugs or having drunk some serious alcohol for this, because this shit makes barely any sense, there's shit in here which you would expect to find in gen 2, and not on a graphics system like the DS, like actually, you'd think they'd be past this by now, but of course not, since this is GF code here. This is not made any better by the fucking compiler, which only does what you'd expect half the fucking time, and the other half of the time needs a weird hack or just straight up won't work, I've had to explicitly cast to u8 a few times because that gets the compiler to work, even if the original variable is of u8, I am genuinely starting to be convinced that metrowerks, freescale, nintendo, and game freak all got together and threw a massive drug party that lasted a few months and designed and programmed the games, libraries, tools, and compilers used in it

I still have a bunch to do here, but I'm only so masochistic, and every single second I take another look at this file I am losing braincells, I need them to continue to push these roms forward, because we only have a few contributors who are working on gen 4.