### PR TITLE
Convert hyphens to underscores in generated GMM header's include-guard

### DIFF
--- a/tools/msgenc/Gmm.cpp
+++ b/tools/msgenc/Gmm.cpp
@@ -40,6 +40,7 @@ void GMM::WriteGmmHeader(const string &_filename) {
         switch (c) {
         case '/':
         case '.':
+        case '-':
             c = '_';
             break;
         default:


### PR DESCRIPTION
`-` is not a valid token in preprocessor tokens, but is common enough in directory names to be worth handling. (we had a user have this issue in `pokeplatinum`, so distributing a fix)